### PR TITLE
◎トップページに最新記事を6件表示。

### DIFF
--- a/_wp/app/public/local-phpinfo.php
+++ b/_wp/app/public/local-phpinfo.php
@@ -1,0 +1,1 @@
+<?php phpinfo();

--- a/_wp/app/public/wp-content/themes/senchawan/footer.php
+++ b/_wp/app/public/wp-content/themes/senchawan/footer.php
@@ -14,33 +14,9 @@
 
 ?>
 
-		</div><!-- #content -->
+		
 
-		<footer id="colophon" class="site-footer" role="contentinfo">
-			<div class="wrap">
-				<?php
-				get_template_part( 'template-parts/footer/footer', 'widgets' );
-
-				if ( has_nav_menu( 'social' ) ) : ?>
-					<nav class="social-navigation" role="navigation" aria-label="<?php esc_attr_e( 'Footer Social Links Menu', 'twentyseventeen' ); ?>">
-						<?php
-							wp_nav_menu( array(
-								'theme_location' => 'social',
-								'menu_class'     => 'social-links-menu',
-								'depth'          => 1,
-								'link_before'    => '<span class="screen-reader-text">',
-								'link_after'     => '</span>' . twentyseventeen_get_svg( array( 'icon' => 'chain' ) ),
-							) );
-						?>
-					</nav><!-- .social-navigation -->
-				<?php endif;
-
-				get_template_part( 'template-parts/footer/site', 'info' );
-				?>
-			</div><!-- .wrap -->
-		</footer><!-- #colophon -->
-	</div><!-- .site-content-contain -->
-</div><!-- #page -->
+		
 <?php wp_footer(); ?>
 
 </body>

--- a/_wp/app/public/wp-content/themes/senchawan/header.php
+++ b/_wp/app/public/wp-content/themes/senchawan/header.php
@@ -23,37 +23,4 @@
 	wp_head();
 ?>
 </head>
-
-<body <?php body_class(); ?>>
-<div id="page" class="site">
-	<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'twentyseventeen' ); ?></a>
-
-	<header id="masthead" class="site-header" role="banner">
-
-		<?php get_template_part( 'template-parts/header/header', 'image' ); ?>
-
-		<?php if ( has_nav_menu( 'top' ) ) : ?>
-			<div class="navigation-top">
-				<div class="wrap">
-					<?php get_template_part( 'template-parts/navigation/navigation', 'top' ); ?>
-				</div><!-- .wrap -->
-			</div><!-- .navigation-top -->
-		<?php endif; ?>
-
-	</header><!-- #masthead -->
-
-	<?php
-
-	/*
-	 * If a regular post or page, and not the front page, show the featured image.
-	 * Using get_queried_object_id() here since the $post global may not be set before a call to the_post().
-	 */
-	if ( ( is_single() || ( is_page() && ! twentyseventeen_is_frontpage() ) ) && has_post_thumbnail( get_queried_object_id() ) ) :
-		echo '<div class="single-featured-image-header">';
-		echo get_the_post_thumbnail( get_queried_object_id(), 'twentyseventeen-featured-image' );
-		echo '</div><!-- .single-featured-image-header -->';
-	endif;
-	?>
-
-	<div class="site-content-contain">
-		<div id="content" class="site-content">
+<body>

--- a/_wp/app/public/wp-content/themes/senchawan/index.php
+++ b/_wp/app/public/wp-content/themes/senchawan/index.php
@@ -17,51 +17,21 @@
 
 get_header(); ?>
 
-<div class="wrap">
-	<?php if ( is_home() && ! is_front_page() ) : ?>
-		<header class="page-header">
-			<h1 class="page-title"><?php single_post_title(); ?></h1>
-		</header>
-	<?php else : ?>
-	<header class="page-header">
-		<h2 class="page-title"><?php _e( 'Posts', 'twentyseventeen' ); ?></h2>
-	</header>
-	<?php endif; ?>
-
-	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
-
-			<?php
-			if ( have_posts() ) :
-
-				/* Start the Loop */
-				while ( have_posts() ) : the_post();
-
-					/*
-					 * Include the Post-Format-specific template for the content.
-					 * If you want to override this in a child theme, then include a file
-					 * called content-___.php (where ___ is the Post Format name) and that will be used instead.
-					 */
-					get_template_part( 'template-parts/post/content', get_post_format() );
-
-				endwhile;
-
-				the_posts_pagination( array(
-					'prev_text' => twentyseventeen_get_svg( array( 'icon' => 'arrow-left' ) ) . '<span class="screen-reader-text">' . __( 'Previous page', 'twentyseventeen' ) . '</span>',
-					'next_text' => '<span class="screen-reader-text">' . __( 'Next page', 'twentyseventeen' ) . '</span>' . twentyseventeen_get_svg( array( 'icon' => 'arrow-right' ) ),
-					'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'twentyseventeen' ) . ' </span>',
-				) );
-
-			else :
-
-				get_template_part( 'template-parts/post/content', 'none' );
-
-			endif;
-			?>
-
-		</main><!-- #main -->
-	</div><!-- #primary -->
-	<?php get_sidebar(); ?>
-</div><!-- .wrap -->
+<!-- 最新記事を取得 -->
+<?php
+  $args = array(
+    'post_type' => 'post',
+    'posts_per_page' => 6
+  );
+  $st_query = new WP_Query( $args );
+?>
+<?php if ( $st_query->have_posts() ): ?>
+  <?php while ( $st_query->have_posts() ) : $st_query->the_post(); ?>
+    <?php the_time( 'Y年m月d日' ); ?><br />
+    <a href="<?php the_permalink(); ?>"><?php the_title(); ?></a><br />
+  <?php endwhile; ?>
+<?php else: ?>
+  <p>新しい記事はありません</p>
+<?php endif; ?>
 
 <?php get_footer();


### PR DESCRIPTION
◎トップページに最新記事を6件表示。
・タイトルと日付は取得できた。
・サムネイル・カテゴリ名も取得できるようにする。
・ひとまず先にコラム詳細ページの実装から進めたほうが合理的。
・カスタムフィールドのプラグインを導入する。

◎ヘッダー・フッターの余分な記述を削除