### PR TITLE
◎コラム詳細の小見出し・キャプションについては、デフォルトの機能を用いる。

### DIFF
--- a/_wp/app/public/css/columnDetail.css
+++ b/_wp/app/public/css/columnDetail.css
@@ -1,0 +1,17 @@
+.txt-column p strong {
+	font-size: 18px;
+	line-height: 1.5;
+	display: block;
+	border-bottom: solid 1px #333;
+	padding-bottom: 13px;
+	margin: 20px 0 24px;
+}
+
+.txt-column p em {
+	font-size: 14px;
+	color: #888;
+	display: block;
+	padding: 16px 0 14px;
+	border-top: solid 1px #888;
+	border-bottom: solid 1px #888;
+}

--- a/_wp/app/public/wp-content/themes/senchawan/header.php
+++ b/_wp/app/public/wp-content/themes/senchawan/header.php
@@ -18,6 +18,8 @@
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
+<link rel="stylesheet" type="text/css" href="/css/columnDetail.css">
+
 <?php
 	wp_deregister_script( 'jquery' ); 
 	wp_head();


### PR DESCRIPTION
・小見出し／管理画面上でボールドを指定。ソースコード上は<strong>タグにスタイルを指定する。
・キャプション／管理画面上でイタリックを指定。ソースコード上は<em>タグにスタイルを指定する。