### PR TITLE
wordpressの調整

### DIFF
--- a/_src/about/index.ejs
+++ b/_src/about/index.ejs
@@ -38,7 +38,7 @@ var cssFileName = ["about"];
 	</div><!-- /.box-description -->
 		
 	<div class="box-description">
-		<h2 class="ttl-description">What is “KUTANI”</h2>
+		<h2 class="ttl-description txt-fontAlphabet">What is “KUTANI”</h2>
 	
 		<p class="txt-About txt-fontAlphabet">I will input the CONCEPT from here.I will input the CONCEPT from here.<br>
 			I will input the CONCEPT from here.I will input the CONCEPT from here.<br>
@@ -50,7 +50,7 @@ var cssFileName = ["about"];
 	</div><!-- /.box-description -->
 
 	<div class="box-writer">
-		<h2 class="ttl-description">What is “KUTANI”</h2>
+		<h2 class="ttl-description txt-fontAlphabet">What is “KUTANI”</h2>
 		
 		<div class="box-writerInfo">
 			<p class="txt-About txt-fontAlphabet">I will input the CONCEPT from here.I will input the CONCEPT from here.<br>

--- a/_wp/app/public/wp-content/themes/senchawan/functions.php
+++ b/_wp/app/public/wp-content/themes/senchawan/functions.php
@@ -576,6 +576,10 @@ remove_action('wp_head', 'rsd_link');
 remove_action('wp_head', 'wlwmanifest_link');
 remove_action('wp_head', 'wp_shortlink_wp_head');
 remove_action('wp_head', 'adjacent_posts_rel_link_wp_head');
+add_action('wp_enqueue_scripts', function() {
+    wp_deregister_style('wp-block-library');
+});
+remove_action('wp_head', 'rel_canonical');
 
 add_filter( 'wp_resource_hints', 'remove_dns_prefetch', 10, 2 );
 function remove_dns_prefetch( $hints, $relation_type ) {

--- a/_wp/app/public/wp-content/themes/senchawan/header.php
+++ b/_wp/app/public/wp-content/themes/senchawan/header.php
@@ -27,12 +27,6 @@
 <?php } else if( is_single() ) { // 記事ページ ?>
 <meta name="description" content="ダミーダミー記事のディスクリプション。">
 <?php } ?>
-<?php // ▼og:url ?>
-<?php if (is_home() && !is_paged()) { // トップページ ?>
-<meta property="og:url" content="<?php echo home_url( '/' ); ?>" />
-<?php } else if (!is_home()) { // トップページ以外 ?>
-<meta property="og:url" content="<?php echo the_permalink(); ?>" />
-<?php } ?>
 <?php // ▼og:title  ?>
 <?php if (is_home() && !is_paged()) { // トップページ ?>
 <meta property="og:title" content="q" />
@@ -43,15 +37,11 @@
 <?php } else if( is_single() ) { // 記事ページ ?>
 <meta property="og:title" content=" <?php the_title(); ?> | q" />
 <?php } ?>
-<?php // ▼og:description  ?>
+<?php // ▼og:type  ?>
 <?php if (is_home() && !is_paged()) { // トップページ ?>
-<meta property="og:description" content="トップのOGディスクリプション" />
-<?php } else if(is_page( '453' )) { // アバウトページ ?>
-<meta property="og:description" content="アバウトのOGディスクリプション" />
-<?php } else if(is_page( '2' ) or is_archive()) { // コラム一覧ページ ?>
-<meta property="og:description" content="コラム一覧のOGディスクリプション" />
-<?php } else if( is_single() ) { // 記事ページ ?>
-<meta property="og:description" content="記事のOGディスクリプション" />
+<meta property="og:type" content="website">
+<?php } else { // トップページ以外 ?>
+<meta property="og:type" content="article">
 <?php } ?>
 <?php // ▼og:image  ?>
 <?php if (is_home() && !is_paged()) { // トップページ ?>
@@ -61,10 +51,12 @@
 <?php } else if( is_single() ) { // 記事ページ ?>
 <meta property="og:image" content="<?php $eye_img = wp_get_attachment_image_src( get_post_thumbnail_id() , 'full' ); print_r($eye_img[0]); ?>" />
 <?php } ?>
-<meta property="og:site_name" content="q" />
-<meta property="og:type" content="article">
-<meta property="fb:app_id" content="サンプルID">
-<meta property="og:locale" content="ja_JP" />
+<?php // ▼og:url ?>
+<?php if (is_home() && !is_paged()) { // トップページ ?>
+<meta property="og:url" content="<?php echo home_url( '/' ); ?>" />
+<?php } else if (!is_home()) { // トップページ以外 ?>
+<meta property="og:url" content="<?php echo the_permalink(); ?>" />
+<?php } ?>
 <link rel="stylesheet" type="text/css" href="/css/base.min.css">
 </head>
 <?php // ▼bodyタグ ?>

--- a/_wp/app/public/wp-content/themes/senchawan/index.php
+++ b/_wp/app/public/wp-content/themes/senchawan/index.php
@@ -2,7 +2,7 @@
 
 <div class="box-content-home">
 
-<!-- 最新記事1件を取得 -->
+<?php // 最新記事1件を取得 ?>
 <?php
   $args = array(
     'post_type' => 'post',
@@ -21,7 +21,7 @@
 			<p class="txt-mainVisualCategory txt-fontAlphabet"><?php echo get_cat_name(get_the_category()[0]->term_id); ?></p>
 			<p class="ttl-mainVisual-english txt-fontAlphabet"><?php the_field('ttlColumnEnglish'); ?></p>
 			<p class="ttl-mainVisual-japanese"><?php the_title(); ?></p>
-			<p class="txt-mainVisualDate"><?php the_time('Y.m.d'); ?></p>
+			<p class="txt-mainVisualDate"><?php the_time('d / m / Y'); ?></p>
 		</div>
 	</a>
 	<?php endwhile; ?>
@@ -30,7 +30,7 @@
 <?php endif; ?>
 </div><!-- /.box-mainVisual -->
 
-<!-- その他の最新記事を取得 -->
+<?php // その他の最新記事を取得 ?>
 <?php
   $args = array(
     'post_type' => 'post',

--- a/_wp/app/public/wp-content/themes/senchawan/page-about.php
+++ b/_wp/app/public/wp-content/themes/senchawan/page-about.php
@@ -6,9 +6,7 @@
 
 
 
-<h1 class="ttl-pageHead txt-fontAlphabet">
-	About
-</h1><!-- /.ttl-pageHead -->
+<h1 class="ttl-pageHead txt-fontAlphabet">About</h1><!-- /.ttl-pageHead -->
 
 	<div class="box-description">
 		<h2 class="ttl-description txt-fontAlphabet">What is “q”</h2>
@@ -23,7 +21,7 @@
 	</div><!-- /.box-description -->
 		
 	<div class="box-description">
-		<h2 class="ttl-description">What is “KUTANI”</h2>
+		<h2 class="ttl-description txt-fontAlphabet">What is “KUTANI”</h2>
 	
 		<p class="txt-About txt-fontAlphabet">I will input the CONCEPT from here.I will input the CONCEPT from here.<br>
 			I will input the CONCEPT from here.I will input the CONCEPT from here.<br>
@@ -35,7 +33,7 @@
 	</div><!-- /.box-description -->
 
 	<div class="box-writer">
-		<h2 class="ttl-description">What is “KUTANI”</h2>
+		<h2 class="ttl-description txt-fontAlphabet">What is “KUTANI”</h2>
 		
 		<div class="box-writerInfo">
 			<p class="txt-About txt-fontAlphabet">I will input the CONCEPT from here.I will input the CONCEPT from here.<br>

--- a/_wp/app/public/wp-content/themes/senchawan/page-new-arrival.php
+++ b/_wp/app/public/wp-content/themes/senchawan/page-new-arrival.php
@@ -27,7 +27,7 @@ $the_query = new WP_Query($args);
 </ul><!-- /.list-column -->
 
 <?php // ページネーション（archive.phpとは形式が違うので注意） ?>
-<nav class="navigation pagination" role="navigation">
+<nav class="navigation pagination">
 	<div class="nav-links">
 		<?php $paged = (int) get_query_var('paged'); ?>
 		<?php $the_query = new WP_Query($args);?>

--- a/_wp/app/public/wp-content/themes/senchawan/single.php
+++ b/_wp/app/public/wp-content/themes/senchawan/single.php
@@ -14,11 +14,11 @@
 <?php get_template_part( 'template-parts/column-detail/list-tag', get_post_format() ); ?>
 
 <div class="box-shareButton">
-	<span>SHARE ON</span>
+	<span>Share it!</span>
 	<?php if ( function_exists( 'ADDTOANY_SHARE_SAVE_KIT' ) ) { 
-	    ADDTOANY_SHARE_SAVE_KIT( array( 
-	        'buttons' => array( 'facebook' ),
-	    ) );
+		ADDTOANY_SHARE_SAVE_KIT( array( 
+			'buttons' => array( 'facebook', 'twitter' ),
+		) );
 	} ?>
 </div><!-- /.box-shareButton -->
 

--- a/_wp/app/public/wp-content/themes/senchawan/template-parts/list-column/box-column.php
+++ b/_wp/app/public/wp-content/themes/senchawan/template-parts/list-column/box-column.php
@@ -5,7 +5,7 @@
 			<p class="txt-columnCategory txt-fontAlphabet"><?php echo get_cat_name(get_the_category()[0]->term_id); ?></p>
 		</div><!-- /.img-column -->
 		<p class="ttl-column ttl-column-english txt-fontAlphabet"><?php the_field('ttlColumnEnglish'); ?></p>
-		<p class="ttl-column ttl-column-japanese txt-fontAlphabet"><?php the_title(); ?></p>
-		<p class="txt-columnDate"><?php the_time('Y.m.d'); ?></p>
+		<p class="ttl-column ttl-column-japanese"><?php the_title(); ?></p>
+		<p class="txt-columnDate"><?php the_time('d / m / Y'); ?></p>
 	</a><!-- /.box-column -->
 </li><!-- /.item-column -->

--- a/template/base/head.ejs
+++ b/template/base/head.ejs
@@ -6,20 +6,14 @@
     <meta name="description" content="<%= meta.description %>">
     
     <%# ogタグ %>
-    <meta property="og:url" content="https://www.shimo.space<%= meta.ogUrl %>" />
     <meta property="og:title" content="<%= meta.ogTitle %>" />
-
     <% if( pageId !== "top" ) { %>
     <meta property="og:type" content="article">
     <% } else { %>
     <meta property="og:type" content="website">
     <% }; %>
-
-    <meta property="og:description" content="<%= meta.ogDescription %>" />
-    <meta property="og:image" content="<%= meta.ogImage %>" />
-    <meta property="og:site_name" content="サンプルサイトネーム" />
-    <meta property="fb:app_id" content="サンプルID">
-    <meta property="og:locale" content="ja_JP" />
+    <meta property="og:image" content="<%= meta.ogImage %>" />   
+    <meta property="og:url" content="https://www.shimo.space<%= meta.ogUrl %>" />
 
     <%# ファビコン %>
     <link rel="icon" href="ファビコンのサンプル" sizes="16x16" type="image/png">


### PR DESCRIPTION
・aboutページの小見出しのフォントを修正
・head内の余分なcssを削除
・カノニカルの設定を削除
・余分なOGPを削除
・homeページのhtml形式のコメントアウトをphp形式に変更
・ページネーションの『role』属性を削除。カテゴリごとの一覧ページの『role』属性は削除できなかった
・ツイッターのシェアボタンを追加
・リスト部分の日付の表示を英語形式に変更